### PR TITLE
Replace "EOS.undent" with "~EOS"

### DIFF
--- a/Abstract/abstract-blackfire-php-extension.rb
+++ b/Abstract/abstract-blackfire-php-extension.rb
@@ -16,7 +16,7 @@ class InvalidPhpVersionError < RuntimeError
 
   def initialize (installed_php_version, required_php_version)
     @name = name
-    super <<-EOS.undent
+    super <<~EOS
       Version of PHP (#{installed_php_version}) in $PATH does not support this extension
              version (#{required_php_version}). Consider installing blackfire-php-#{installed_php_version} with the `--without-homebrew-php` flag.
     EOS
@@ -96,7 +96,7 @@ class AbstractBlackfirePhpExtension < Formula
 
   def config_file
     begin
-      <<-EOS.undent
+      <<~EOS
       [#{extension}]
       extension="#{module_path}"
       EOS

--- a/Formula/blackfire-php53-zts.rb
+++ b/Formula/blackfire-php53-zts.rb
@@ -16,7 +16,7 @@ class BlackfirePhp53Zts < AbstractBlackfirePhpExtension
     end
 
     def config_file
-        super + <<-EOS.undent
+        super + <<~EOS
         blackfire.agent_socket = unix:///usr/local/var/run/blackfire-agent.sock
         blackfire.agent_timeout = 0.25
         ;blackfire.log_level = 3

--- a/Formula/blackfire-php53.rb
+++ b/Formula/blackfire-php53.rb
@@ -16,7 +16,7 @@ class BlackfirePhp53 < AbstractBlackfirePhpExtension
     end
 
     def config_file
-        super + <<-EOS.undent
+        super + <<~EOS
         blackfire.agent_socket = unix:///usr/local/var/run/blackfire-agent.sock
         blackfire.agent_timeout = 0.25
         ;blackfire.log_level = 3

--- a/Formula/blackfire-php54-zts.rb
+++ b/Formula/blackfire-php54-zts.rb
@@ -16,7 +16,7 @@ class BlackfirePhp54Zts < AbstractBlackfirePhpExtension
     end
 
     def config_file
-        super + <<-EOS.undent
+        super + <<~EOS
         blackfire.agent_socket = unix:///usr/local/var/run/blackfire-agent.sock
         blackfire.agent_timeout = 0.25
         ;blackfire.log_level = 3

--- a/Formula/blackfire-php54.rb
+++ b/Formula/blackfire-php54.rb
@@ -16,7 +16,7 @@ class BlackfirePhp54 < AbstractBlackfirePhpExtension
     end
 
     def config_file
-        super + <<-EOS.undent
+        super + <<~EOS
         blackfire.agent_socket = unix:///usr/local/var/run/blackfire-agent.sock
         blackfire.agent_timeout = 0.25
         ;blackfire.log_level = 3

--- a/Formula/blackfire-php55-zts.rb
+++ b/Formula/blackfire-php55-zts.rb
@@ -16,7 +16,7 @@ class BlackfirePhp55Zts < AbstractBlackfirePhpExtension
     end
 
     def config_file
-        super + <<-EOS.undent
+        super + <<~EOS
         blackfire.agent_socket = unix:///usr/local/var/run/blackfire-agent.sock
         blackfire.agent_timeout = 0.25
         ;blackfire.log_level = 3

--- a/Formula/blackfire-php55.rb
+++ b/Formula/blackfire-php55.rb
@@ -16,7 +16,7 @@ class BlackfirePhp55 < AbstractBlackfirePhpExtension
     end
 
     def config_file
-        super + <<-EOS.undent
+        super + <<~EOS
         blackfire.agent_socket = unix:///usr/local/var/run/blackfire-agent.sock
         blackfire.agent_timeout = 0.25
         ;blackfire.log_level = 3

--- a/Formula/blackfire-php56-zts.rb
+++ b/Formula/blackfire-php56-zts.rb
@@ -16,7 +16,7 @@ class BlackfirePhp56Zts < AbstractBlackfirePhpExtension
     end
 
     def config_file
-        super + <<-EOS.undent
+        super + <<~EOS
         blackfire.agent_socket = unix:///usr/local/var/run/blackfire-agent.sock
         blackfire.agent_timeout = 0.25
         ;blackfire.log_level = 3

--- a/Formula/blackfire-php56.rb
+++ b/Formula/blackfire-php56.rb
@@ -16,7 +16,7 @@ class BlackfirePhp56 < AbstractBlackfirePhpExtension
     end
 
     def config_file
-        super + <<-EOS.undent
+        super + <<~EOS
         blackfire.agent_socket = unix:///usr/local/var/run/blackfire-agent.sock
         blackfire.agent_timeout = 0.25
         ;blackfire.log_level = 3

--- a/Formula/blackfire-php70-zts.rb
+++ b/Formula/blackfire-php70-zts.rb
@@ -16,7 +16,7 @@ class BlackfirePhp70Zts < AbstractBlackfirePhpExtension
     end
 
     def config_file
-        super + <<-EOS.undent
+        super + <<~EOS
         blackfire.agent_socket = unix:///usr/local/var/run/blackfire-agent.sock
         blackfire.agent_timeout = 0.25
         ;blackfire.log_level = 3

--- a/Formula/blackfire-php70.rb
+++ b/Formula/blackfire-php70.rb
@@ -16,7 +16,7 @@ class BlackfirePhp70 < AbstractBlackfirePhpExtension
     end
 
     def config_file
-        super + <<-EOS.undent
+        super + <<~EOS
         blackfire.agent_socket = unix:///usr/local/var/run/blackfire-agent.sock
         blackfire.agent_timeout = 0.25
         ;blackfire.log_level = 3

--- a/Formula/blackfire-php71-zts.rb
+++ b/Formula/blackfire-php71-zts.rb
@@ -16,7 +16,7 @@ class BlackfirePhp71Zts < AbstractBlackfirePhpExtension
     end
 
     def config_file
-        super + <<-EOS.undent
+        super + <<~EOS
         blackfire.agent_socket = unix:///usr/local/var/run/blackfire-agent.sock
         blackfire.agent_timeout = 0.25
         ;blackfire.log_level = 3

--- a/Formula/blackfire-php71.rb
+++ b/Formula/blackfire-php71.rb
@@ -16,7 +16,7 @@ class BlackfirePhp71 < AbstractBlackfirePhpExtension
     end
 
     def config_file
-        super + <<-EOS.undent
+        super + <<~EOS
         blackfire.agent_socket = unix:///usr/local/var/run/blackfire-agent.sock
         blackfire.agent_timeout = 0.25
         ;blackfire.log_level = 3

--- a/Formula/blackfire-php72-zts.rb
+++ b/Formula/blackfire-php72-zts.rb
@@ -16,7 +16,7 @@ class BlackfirePhp72Zts < AbstractBlackfirePhpExtension
     end
 
     def config_file
-        super + <<-EOS.undent
+        super + <<~EOS
         blackfire.agent_socket = unix:///usr/local/var/run/blackfire-agent.sock
         blackfire.agent_timeout = 0.25
         ;blackfire.log_level = 3

--- a/Formula/blackfire-php72.rb
+++ b/Formula/blackfire-php72.rb
@@ -16,7 +16,7 @@ class BlackfirePhp72 < AbstractBlackfirePhpExtension
     end
 
     def config_file
-        super + <<-EOS.undent
+        super + <<~EOS
         blackfire.agent_socket = unix:///usr/local/var/run/blackfire-agent.sock
         blackfire.agent_timeout = 0.25
         ;blackfire.log_level = 3


### PR DESCRIPTION
`EOS.undent` is deprecated since several months and must be replaced by `~EOS`.

The blackfire-phpXX install now fails with :

```
Error: Calling <<-EOS.undent is disabled!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/blackfireio/homebrew-blackfire/Formula/blackfire-php56.rb:26:in `config_file'
Please report this to the blackfireio/blackfire tap!
Or, even better, submit a PR to fix it!
```