### PR TITLE
Update for disabled module

### DIFF
--- a/Abstract/abstract-blackfire-php-extension.rb
+++ b/Abstract/abstract-blackfire-php-extension.rb
@@ -164,7 +164,7 @@ EOS
   def write_config_file
     if config_filepath.file?
       inreplace config_filepath do |s|
-        s.gsub!(/^(zend_)?extension=.+$/, "extension=\"#{module_path}\"")
+        s.gsub!(/^(;)?(zend_)?extension=.+$/, "extension=\"#{module_path}\"")
       end
     elsif config_file
       config_scandir_path.mkpath

--- a/Abstract/abstract-blackfire-php-extension.rb
+++ b/Abstract/abstract-blackfire-php-extension.rb
@@ -164,7 +164,7 @@ EOS
   def write_config_file
     if config_filepath.file?
       inreplace config_filepath do |s|
-        s.gsub!(/^(;)?(zend_)?extension=.+$/, "extension=\"#{module_path}\"")
+        s.gsub!(/^(;\s*)?(zend_)?extension=.+$/, "extension=\"#{module_path}\"")
       end
     elsif config_file
       config_scandir_path.mkpath


### PR DESCRIPTION
Disabled module has config:
```
[blackfire]
;extension="/usr/local/Cellar/blackfire-php80/1.53.0/blackfire.so"
blackfire.agent_socket = unix:///usr/local/var/run/blackfire-agent.sock
;blackfire.log_level = 3
;blackfire.log_file = /tmp/blackfire.log
```

I have error on update:
```
==> Upgrading blackfireio/blackfire/blackfire-php80 1.53.0 -> 1.54.0
==> Downloading https://packages.blackfire.io/homebrew/blackfire-php_1.54.0-darwin_amd64-php80.tar.gz
######################################################################## 100.0%
Error: An exception occurred within a child process:
  Utils::Inreplace::Error: inreplace failed
/usr/local/etc/php/8.0/conf.d/ext-blackfire.ini:
  expected replacement of /^(zend_)?extension=.+$/ with "extension=\"/usr/local/Cellar/blackfire-php80/1.54.0/blackfire.so\""
```