### PR TITLE
blackfire-php73 does not work on arm64 mac silicon

### DIFF
--- a/Formula/blackfire-php73.rb
+++ b/Formula/blackfire-php73.rb
@@ -7,9 +7,15 @@ class BlackfirePhp73 < AbstractBlackfirePhpExtension
     homepage "https://blackfire.io"
     version '1.80.0'
 
-    url 'https://packages.blackfire.io/homebrew/blackfire-php_1.80.0-darwin_amd64-php73.tar.gz'
-    sha256 '7f7149485b139d2595925139bee2a5444ff83696748e66c301887bfe7e54a533'
 
+    if Hardware::CPU.arm?
+        url 'https://packages.blackfire.io/homebrew/blackfire-php_1.80.0-darwin_arm64-php73.tar.gz'
+        sha256 'TODO'
+    else
+        url 'https://packages.blackfire.io/homebrew/blackfire-php_1.80.0-darwin_amd64-php73.tar.gz'
+        sha256 '7f7149485b139d2595925139bee2a5444ff83696748e66c301887bfe7e54a533'
+    end
+    
     def install
         prefix.install "blackfire.so"
         write_config_file


### PR DESCRIPTION
I can't raise an issue so raising a partial PR to start the discussion.

I see these files have updated recently, I swear `blackfire-php73` used to work for me but no longer does. due to `mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e'`

```
$ php --version
PHP Warning:  PHP Startup: Unable to load dynamic library '/opt/homebrew/Cellar/blackfire-php73/1.80.0/blackfire.so' (tried: /opt/homebrew/Cellar/blackfire-php73/1.80.0/blackfire.so (dlopen(/opt/homebrew/Cellar/blackfire-php73/1.80.0/blackfire.so, 0x0009): tried: '/opt/homebrew/Cellar/blackfire-php73/1.80.0/blackfire.so' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e')), '/usr/local/lib/blackfire.so' (no such file), '/usr/lib/blackfire.so' (no such file)), /opt/homebrew/lib/php/pecl/20180731//opt/homebrew/Cellar/blackfire-php73/1.80.0/blackfire.so.so (dlopen(/opt/homebrew/lib/php/pecl/20180731//opt/homebrew/Cellar/blackfire-php73/1.80.0/blackfire.so.so, 0x0009): tried: '/opt/homebrew/lib/php/pecl/20180731//opt/homebrew/Cellar/blackfire-php73/1.80.0/blackfire.so.so' (no such file), '/usr/local/lib/blackfire.so.so' (no such file), '/usr/lib/blackfire.so.so' (no such file))) in Unknown on line 0

Warning: PHP Startup: Unable to load dynamic library '/opt/homebrew/Cellar/blackfire-php73/1.80.0/blackfire.so' (tried: /opt/homebrew/Cellar/blackfire-php73/1.80.0/blackfire.so (dlopen(/opt/homebrew/Cellar/blackfire-php73/1.80.0/blackfire.so, 0x0009): tried: '/opt/homebrew/Cellar/blackfire-php73/1.80.0/blackfire.so' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e')), '/usr/local/lib/blackfire.so' (no such file), '/usr/lib/blackfire.so' (no such file)), /opt/homebrew/lib/php/pecl/20180731//opt/homebrew/Cellar/blackfire-php73/1.80.0/blackfire.so.so (dlopen(/opt/homebrew/lib/php/pecl/20180731//opt/homebrew/Cellar/blackfire-php73/1.80.0/blackfire.so.so, 0x0009): tried: '/opt/homebrew/lib/php/pecl/20180731//opt/homebrew/Cellar/blackfire-php73/1.80.0/blackfire.so.so' (no such file), '/usr/local/lib/blackfire.so.so' (no such file), '/usr/lib/blackfire.so.so' (no such file))) in Unknown on line 0
PHP 7.3.3 (cli) (built: Apr 14 2022 09:59:53) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.3.3, Copyright (c) 1998-2018 Zend Technologies
    with Xdebug v2.7.2, Copyright (c) 2002-2019, by Derick Rethans
```

I did compare with `blackfire-php74` which seems to be fine due to the different hardware flags

https://github.com/blackfireio/homebrew-blackfire/blob/542ed513963f1a8fe8f5060412b5292fe3987487/Formula/blackfire-php74.rb#L10-L16

Using the same kind of approach I hoped to be able to use a URL like `https://packages.blackfire.io/homebrew/blackfire-php_1.80.0-darwin_arm64-php73.tar.gz` but no such package exists.
 
Is it possible the `.so` file used to be built in a way that happened to be cross compatible but now is breaking? Can a multi arch file be generated?