### PR TITLE
File.exists is deprecated and removed

### DIFF
--- a/Formula/blackfire-agent.rb
+++ b/Formula/blackfire-agent.rb
@@ -18,7 +18,7 @@ class BlackfireAgent < Formula
         sl_etc = etc + 'blackfire'
         sl_etc.mkpath unless sl_etc.exist?
         sl_etc.install 'etc/blackfire/agent.dist'
-        FileUtils.cp sl_etc+'agent.dist', sl_etc+'agent' unless File.exists? sl_etc+'agent'
+        FileUtils.cp sl_etc+'agent.dist', sl_etc+'agent' unless File.exist? sl_etc+'agent'
 
         sl_log = var+'log/blackfire'
         sl_log.mkpath unless sl_log.exist?

--- a/Formula/blackfire.rb
+++ b/Formula/blackfire.rb
@@ -22,7 +22,7 @@ class Blackfire < Formula
         sl_etc = etc + 'blackfire'
         sl_etc.mkpath unless sl_etc.exist?
         sl_etc.install 'etc/blackfire/agent.dist'
-        FileUtils.cp sl_etc+'agent.dist', sl_etc+'agent' unless File.exists? sl_etc+'agent'
+        FileUtils.cp sl_etc+'agent.dist', sl_etc+'agent' unless File.exist? sl_etc+'agent'
 
         sl_log = var+'log/blackfire'
         sl_log.mkpath unless sl_log.exist?


### PR DESCRIPTION
`brew upgrade` broke for me with:

```
==> Fetching blackfireio/blackfire/blackfire
==> Downloading https://packages.blackfire.io/blackfire/2.28.2/blackfire-darwin_
Already downloaded: /Users/ahebrank/Library/Caches/Homebrew/downloads/771b1fee5db5037bd2b2fc9665be334e977555f47325661e194166f2a34ab4e8--blackfire-darwin_arm64.pkg.tar.gz
==> Installing blackfire from blackfireio/blackfire
Error: An exception occurred within a child process:
  NoMethodError: undefined method `exists?' for class File
```

apparently `File.exists` [has been deprecated for a while](https://docs.ruby-lang.org/en/2.7.0/File.html#method-c-exists-3F).